### PR TITLE
adding abi3-py38 compatibility for python wheel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ nvml-wrapper = "0.10.0"
 blake3 = "1.5.4"
 clap = { version = "4.5.19", features = ["derive"] }
 anyhow = "1.0.89"
-pyo3 = { version = "0.23.3", features = ["extension-module"], optional = true }
+# 'abi3' feature enables Python modules to be used against multiple Python versions
+# see: https://pyo3.rs/v0.13.2/building_and_distribution.html#py_limited_apiabi3
+pyo3 = { version = "0.23.3", features = ["extension-module", "abi3"], optional = true }
 cxx = { version = "1.0", optional = true }
 cc = { version = "1.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clap = { version = "4.5.19", features = ["derive"] }
 anyhow = "1.0.89"
 # 'abi3' feature enables Python modules to be used against multiple Python versions
 # see: https://pyo3.rs/v0.13.2/building_and_distribution.html#py_limited_apiabi3
-pyo3 = { version = "0.23.3", features = ["extension-module", "abi3"], optional = true }
+pyo3 = { version = "0.23.3", features = ["extension-module", "abi3-py38"], optional = true }
 cxx = { version = "1.0", optional = true }
 cc = { version = "1.0", optional = true }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ version = "0.1.2"
 dependencies = ["cffi"]
 readme = "src/python/README.md"
 description = "Library to create a GPU Node ID"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [
   {email = "luccab@meta.com"},


### PR DESCRIPTION
# Summary

This PR relies on abi3 to build a python module that can be used on multiple python versions. Before this PR, gni's python module was only compatible with the exact python version it was compiled against. 

## whats abi3?
[PEP 384](https://peps.python.org/pep-0384/) defines a limited python API with a stable ABI (aka abi3), this limited ABI works across multiple python versions.

# Test Plan

## Before

build on py310 env:
```
$ python -c 'import sys; print(sys.version_info[:])'
(3, 10, 12, 'final', 0)
$ maturin build --release --features=python
…
📦 Built wheel for CPython 3.10 to /path/to/310.whl
```

install on py39 env:
```
$ python -c 'import sys; print(sys.version_info[:])'
(3, 9, 17, 'final', 0)
$ pip install /path/to/310.whl
...
ERROR: 310.whl is not a supported wheel on this platform.
```

## After

build on py310 env:
```
$ python -c 'import sys; print(sys.version_info[:])'
(3, 10, 12, 'final', 0)
$ maturin build --release --features=python
…
📦 Built wheel for CPython 3.10 to /path/to/310.whl
```

install on py39 env:
```
$ python -c 'import sys; print(sys.version_info[:])'
(3, 9, 17, 'final', 0)
$ pip install /path/to/310.whl
…
$ python -c 'import gni_lib; print(gni_lib.get_gpu_node_id())'
<id>
```

