### PR TITLE
building and publishing additional python wheels

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        container:
+        manylinux:
           - manylinux2014
           - manylinux_2_28
         target: [x86_64, aarch64, ppc64le, s390x]
-    container: quay.io/pypa/${{ matrix.container }}_${{ matrix.target }}
+    # container: quay.io/pypa/${{ matrix.container }}_${{ matrix.target }}
 
     steps:
       - name: Github Checkout
@@ -29,13 +29,13 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          manylinux: auto
+          manylinux: ${{ matrix.manylinux }}
           args: --release --features=python --out dist -m Cargo.toml
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels_${{ matrix.container }}_${{ matrix.target }}
+          name: wheels_${{ matrix.manylinux }}_${{ matrix.target }}
           path: dist
   
   release:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -39,7 +39,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     needs: [ linux-build ]
     steps:
       - name: Download Build Artifacts
@@ -52,5 +52,10 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          pip install --upgrade twine
+          twine upload --skip-existing wheels/**/*.whl

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
-          architecture: x64
+          python-version: '3.10'
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -33,10 +33,10 @@ jobs:
           args: --release --features=python --out dist -m Cargo.toml
 
       - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: wheels
-        path: dist
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
   
   release:
     name: Release

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Python Setup
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,0 +1,62 @@
+name: Python Wheel on Multiple manylinux Containers
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linux-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        container:
+          - quay.io/pypa/manylinux2014_x86_64
+          - quay.io/pypa/manylinux_2_24_x86_64
+          - quay.io/pypa/manylinux_2_28_x86_64
+    container: ${{ matrix.container }}
+
+    - name: Github Checkout
+      uses: actions/checkout@v4
+
+    - name: Python Setup
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.10
+        architecture: x64
+
+    - name: Build wheels
+      uses: PyO3/maturin-action@v1
+      with:
+        target: ${{ matrix.target }}
+        manylinux: auto
+        args: --release --features=python --out dist -m Cargo.toml
+
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: dist
+  
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [ linux-build ]
+    steps:
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels
+
+      - name: Python Setup
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          pip install --upgrade twine
+          twine upload --skip-existing *

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -15,23 +15,24 @@ jobs:
           - quay.io/pypa/manylinux_2_28_x86_64
     container: ${{ matrix.container }}
 
-    - name: Github Checkout
-      uses: actions/checkout@v4
+    steps:
+      - name: Github Checkout
+        uses: actions/checkout@v4
 
-    - name: Python Setup
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.10
-        architecture: x64
+      - name: Python Setup
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+          architecture: x64
 
-    - name: Build wheels
-      uses: PyO3/maturin-action@v1
-      with:
-        target: ${{ matrix.target }}
-        manylinux: auto
-        args: --release --features=python --out dist -m Cargo.toml
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          args: --release --features=python --out dist -m Cargo.toml
 
-    - name: Upload wheels
+      - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
         name: wheels

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -1,4 +1,4 @@
-name: Python Wheel on Multiple manylinux Containers
+name: Build Python Wheels
 
 on:
   push:
@@ -13,7 +13,6 @@ jobs:
           - manylinux2014
           - manylinux_2_28
         target: [x86_64, aarch64, ppc64le, s390x]
-    # container: quay.io/pypa/${{ matrix.container }}_${{ matrix.target }}
 
     steps:
       - name: Github Checkout
@@ -40,11 +39,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    # if: startsWith(github.ref, 'refs/tags/')
     needs: [ linux-build ]
     steps:
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: wheels
 
@@ -53,10 +52,12 @@ jobs:
         with:
           python-version: 3.10
 
-      - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          pip install --upgrade twine
-          twine upload --skip-existing *
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+      # - name: Publish to PyPI
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      #   run: |
+      #     pip install --upgrade twine
+      #     twine upload --skip-existing *

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -10,11 +10,10 @@ jobs:
     strategy:
       matrix:
         container:
-          - manylinux2014_x86_64
-          - manylinux_2_24_x86_64
-          - manylinux_2_28_x86_64
-        target: [x86_64, i686]
-    container: quay.io/pypa/${{ matrix.container }}
+          - manylinux2014
+          - manylinux_2_28
+        target: [x86_64, aarch64, ppc64le, s390x]
+    container: quay.io/pypa/${{ matrix.container }}_${{ matrix.target }}
 
     steps:
       - name: Github Checkout

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wheels
+          path: wheels
 
       - name: Python Setup
         uses: actions/setup-python@v4
@@ -54,10 +54,3 @@ jobs:
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-      # - name: Publish to PyPI
-      #   env:
-      #     TWINE_USERNAME: __token__
-      #     TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      #   run: |
-      #     pip install --upgrade twine
-      #     twine upload --skip-existing *

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -10,10 +10,11 @@ jobs:
     strategy:
       matrix:
         container:
-          - quay.io/pypa/manylinux2014_x86_64
-          - quay.io/pypa/manylinux_2_24_x86_64
-          - quay.io/pypa/manylinux_2_28_x86_64
-    container: ${{ matrix.container }}
+          - manylinux2014_x86_64
+          - manylinux_2_24_x86_64
+          - manylinux_2_28_x86_64
+        target: [x86_64, i686]
+    container: quay.io/pypa/${{ matrix.container }}
 
     steps:
       - name: Github Checkout
@@ -33,9 +34,9 @@ jobs:
           args: --release --features=python --out dist -m Cargo.toml
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels_${{ matrix.container }}_${{ matrix.target }}
           path: dist
   
   release:


### PR DESCRIPTION
## Summary

This PR does 2 things:
- Builds a few additional wheels for python with some variations of manylinux and architectures. Enabling gni to be downloaded for those additional environments
- Publishes these wheels to pypi when there's a new github release

## Test Plan

ssh into ci and upload to testpypi
```
runner@fv-az1782-709:~/work/gni/gni$ twine upload --skip-existing -r testpypi wheels/**/*.whl
```

observe files are available on testpypi: https://test.pypi.org/project/gni/#files