### PR TITLE
setting up pypi-publish env

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -39,6 +39,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: pypi-publish
     if: startsWith(github.ref, 'refs/tags/')
     needs: [ linux-build ]
     steps:


### PR DESCRIPTION
## Summary

protecting pypi secret under pypi-publish github env.

CI rules that wants to access pypi_secret, needs to be running under `environment: pypi-publish` and for the rule to actually run it needs a stamp from one of the admins

Following:

- [creating an environment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment#creating-an-environment)
- [using an environment in a workflow](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-environments-for-deployment#using-an-environment-in-a-workflow)